### PR TITLE
Fix private getter / setters on Boolean fields to support Kotlin

### DIFF
--- a/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
+++ b/processor/src/main/java/com/bluelinelabs/logansquare/processor/JsonFieldHolder.java
@@ -77,8 +77,8 @@ public class JsonFieldHolder {
         List<String> possibleMethodNames = new ArrayList<>();
         possibleMethodNames.add("get" + elementNameLowerCase);
         if (elementTypeKind == TypeKind.BOOLEAN) {
-            possibleMethodNames.add("is" + elementNameLowerCase);
-            possibleMethodNames.add("has" + elementNameLowerCase);
+            possibleMethodNames.add("is" + elementName);
+            possibleMethodNames.add("has" + elementName);
             possibleMethodNames.add(elementNameLowerCase);
         }
 
@@ -119,7 +119,7 @@ public class JsonFieldHolder {
         String elementNameLowerCase = elementName.toLowerCase();
 
         List<String> possibleMethodNames = new ArrayList<>();
-        possibleMethodNames.add("set" + elementNameLowerCase);
+        possibleMethodNames.add("set" + elementName);
 
         // Handle the case where variables are named in the form mVariableName instead of just variableName
         if (elementName.length() > 1 && elementName.charAt(0) == 'm' && (elementName.charAt(1) >= 'A' && elementName.charAt(1) <= 'Z')) {


### PR DESCRIPTION
Kotlin classes that use `Boolean` types fail on compile. fixing them you have to define:
```kotlin
@JsonObject(fieldDetectionPolicy = JsonObject.FieldDetectionPolicy.NONPRIVATE_FIELDS_AND_ACCESSORS)
class AccountPreferencesResponse(@JsonField(name = arrayOf("IsOnlinePricingActive"))
                                 @get:JvmName("isonlinePricingActive")
                                 @set:JvmName("setisOnlinePricingActive")
                                 var isOnlinePricingActive: Boolean = false,
                                 @JsonField(name = arrayOf("PreferredStore")) var preferredStore: Int = 0,
                                 @JsonField(name = arrayOf("DefaultShoppingListId")) var defaultShoppingListId: Long = 0,
                                 @JsonField(name = arrayOf("CommunicationPreferences")) var communicationPreferences: AccountPreferencesCommunicationResponse? = null)
```
A seperate getter/setter, which is lowercase. This does not work well with Kotlin. This file change fixes the issue by not using the `elementNameLowerCase` but instead uses `elementName` so we don't need the verbose annotation on any `Boolean` field.